### PR TITLE
Make getEnd relative to context

### DIFF
--- a/smoothscroll.js
+++ b/smoothscroll.js
@@ -27,10 +27,11 @@ if (typeof window !== 'object') return;
 if(document.querySelectorAll === void 0 || window.pageYOffset === void 0 || history.pushState === void 0) { return; }
 
 // Get the top position of an element in the document
-var getEnd = function(element, start, direction) {
+var getEnd = function(element, start, direction, context) {
     // return value of html.getBoundingClientRect().top ... IE : 0, other browsers : -pageYOffset
     if(element.nodeName === 'HTML') return -start
-    return element.getBoundingClientRect()[direction === 'vertical' ? 'top' : 'left'] + start
+    return element.getBoundingClientRect()[direction === 'vertical' ? 'top' : 'left'] + start - 
+			context.getBoundingClientRect()[direction === 'vertical' ? 'top' : 'left']
 }
 // ease in out function thanks to:
 // http://blog.greweb.fr/2012/02/bezier-curve-based-easing-functions-from-concept-to-implementation/
@@ -64,7 +65,7 @@ var smoothScroll = function(el, duration, callback, context, direction){
     if (typeof el === 'number') {
       var end = parseInt(el);
     } else {
-      var end = getEnd(el, start, direction);
+      var end = getEnd(el, start, direction, context);
     }
 
     var clock = Date.now();


### PR DESCRIPTION
In the case where the context element does not span the entire window, smoothScroll was making the next item being scrolled to jump to the left edge of the entire window even if the context element was smaller than the window.
I added the context to the getEnd function so the smoothScroll is in relation to the context element.